### PR TITLE
temporary remove aes256gcmsha384 from the default cipher-suite list t…

### DIFF
--- a/lib/cifra.c
+++ b/lib/cifra.c
@@ -526,5 +526,5 @@ ptls_cipher_suite_t ptls_minicrypto_aes256gcmsha384 = {PTLS_CIPHER_SUITE_AES_256
                                                        &ptls_minicrypto_sha384};
 ptls_cipher_suite_t ptls_minicrypto_chacha20poly1305sha256 = {PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256,
                                                               &ptls_minicrypto_chacha20poly1305, &ptls_minicrypto_sha256};
-ptls_cipher_suite_t *ptls_minicrypto_cipher_suites[] = {&ptls_minicrypto_aes256gcmsha384, &ptls_minicrypto_aes128gcmsha256,
-                                                        &ptls_minicrypto_chacha20poly1305sha256, NULL};
+ptls_cipher_suite_t *ptls_minicrypto_cipher_suites[] = {&ptls_minicrypto_aes128gcmsha256, &ptls_minicrypto_chacha20poly1305sha256,
+                                                        NULL};

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1057,7 +1057,7 @@ ptls_aead_algorithm_t ptls_openssl_chacha20poly1305 = {"CHACHA20-POLY1305",
 ptls_cipher_suite_t ptls_openssl_chacha20poly1305sha256 = {PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256,
                                                            &ptls_openssl_chacha20poly1305, &ptls_openssl_sha256};
 #endif
-ptls_cipher_suite_t *ptls_openssl_cipher_suites[] = {&ptls_openssl_aes256gcmsha384, &ptls_openssl_aes128gcmsha256,
+ptls_cipher_suite_t *ptls_openssl_cipher_suites[] = {&ptls_openssl_aes128gcmsha256,
 #if defined(PTLS_OPENSSL_HAVE_CHACHA20_POLY1305)
                                                      &ptls_openssl_chacha20poly1305sha256,
 #endif


### PR DESCRIPTION
…o fix handshake failure #111

The failure happens when picotls running as a client offers a cipher-suite using SHA384 as
the most preferred choice but the server selects one using SHA256, due to the fact that
current implementation only calculating the handshake hash using the algorithm specified
in the most preferred cipher-suite (e.g., SHA384).